### PR TITLE
Remove duplicate content

### DIFF
--- a/how-to-guides.rst
+++ b/how-to-guides.rst
@@ -37,15 +37,3 @@ If you disable a service and also want to remove all the associated files, refer
    
    Disable and purge <pro-client/purging_services.rst>  
 
-.. toctree::
-   :maxdepth: 1
-
-   Enable Anbox Cloud <pro-client/enable_anbox.rst>
-   Enable Ubuntu Security Guide/CIS hardening tool <pro-client/enable_cis.rst>
-   Enable ESM-apps and ESM-infra <pro-client/enable_esm_infra.rst>
-   Enable FIPS <pro-client/enable_fips.rst>
-   Enable Landscape <pro-client/enable_landscape.rst>
-   Enable Livepatch <pro-client/enable_livepatch.rst>
-   Enable real-time kernel <pro-client/enable_realtime_kernel.rst>
-   Disable and purge <pro-client/purging_services.rst>
-

--- a/index.rst
+++ b/index.rst
@@ -19,7 +19,7 @@ In this documentation
    .. grid-item-card:: :ref:`Start here <start-here>`
        :columns: 12
 
-       Get started with Ubuntu Pro: :ref:`Set up your account <account-setup>`, :ref:`get your token and attach it <get_token_and_attach>` and learn :ref:`how to use the Pro client <tutorial-commands>`
+       Get started with Ubuntu Pro: :ref:`Set up your account <account-setup>`, :ref:`attach a machine to your subscription <get_token_and_attach>` and learn :ref:`how to use the Pro client <tutorial-commands>`
 
 .. grid:: 2
    :gutter: 3
@@ -38,7 +38,7 @@ In this documentation
 **Popular questions**
 
 * :ref:`Why can't I access my Ubuntu Pro account? <account-problems>`
-* :ref:`How do I use my Ubuntu Pro token? <get_token_and_attach>`
+* :ref:`How do I attach a machine to my subscription? <get_token_and_attach>`
 * :ref:`How are active machines calculated? <active-machine-count>`
 * :ref:`How do I set up Ubuntu Pro on offline machines? <airgapped>`
 

--- a/pro-client/basic_commands.rst
+++ b/pro-client/basic_commands.rst
@@ -82,20 +82,33 @@ We have seen which service offerings are available to us, but to access them we
 first need to attach an Ubuntu Pro subscription. We can do this by running the
 ``attach`` command.
 
-Before you run this command, you will need to get your Ubuntu Pro token. Any
-user with an Ubuntu One account is entitled to a free personal token to use
-with Ubuntu Pro.
+.. code-block:: bash
 
-You can retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_.
-Log in with your "single sign on" (SSO) credentials -- the same credentials you
-use for https://login.ubuntu.com. Copy your Ubuntu Pro token, then go to the VM
-and run:
+    $ sudo pro attach
+    
+You should see output like this, giving you a link and a code:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN
+    ubuntu@test:~$ sudo pro attach
+    Initiating attach operation...
 
-You should then see output similar to this:
+    Please sign in to your Ubuntu Pro account at this link:
+    https://ubuntu.com/pro/attach
+    And provide the following code: H31JIV
+
+Open the link without closing your terminal window. 
+
+In the field that asks you to enter your code, copy and paste the code shown
+in the terminal. Then, choose which subscription you want to attach to. 
+By default, the Free Personal Token will be selected, which is fine for the
+purposes of this tutorial.
+
+Once you have pasted your code and chosen the subscription you want to attach
+your machine to, click on the "Submit" button.
+
+The attach process will then continue in the terminal window, and you should
+eventually be presented with the following message:
 
 .. code-block:: text
 

--- a/pro-client/get_token_and_attach.rst
+++ b/pro-client/get_token_and_attach.rst
@@ -1,53 +1,58 @@
 .. _get_token_and_attach:
 
-How to get an Ubuntu Pro token and attach to a subscription
-***********************************************************
+How to attach a machine to your Ubuntu Pro subscription
+*******************************************************
 
-Get an Ubuntu Pro token
-=======================
-
-Retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_. Log in
-with your "Single Sign On" credentials, the same credentials you use for
-https://login.ubuntu.com.
-
-After you have logged in you can go to the
-`Ubuntu Pro Dashboard <Pro_dashboard_>`_ associated with your user account. It
-will show you all subscriptions currently available to you and for each
-associated token.
-
-Note that even without buying anything you can always obtain a free personal
-token that way, which provides you with access to several of the Ubuntu Pro
-services.
-
-Attach to a subscription
-========================
-
-Once you have obtained your token, run the following command to attach your
-machine to a subscription:
+To attach your machine to a subscription, run the following command in your
+terminal:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN
+    $ sudo pro attach
 
-You should see output like this, which indicates that you have successfully
-associated this machine with your account:
+You should see output like this, giving you a link and a code:
 
-.. code-block:: text
+.. code-block:: bash
 
+    ubuntu@test:~$ sudo pro attach
+    Initiating attach operation...
+
+    Please sign in to your Ubuntu Pro account at this link:
+    https://ubuntu.com/pro/attach
+    And provide the following code: H31JIV
+
+Open the link without closing your terminal window. 
+
+In the field that asks you to enter your code, copy and paste the code shown
+in the terminal. Then, choose which subscription you want to attach to. 
+By default, the Free Personal Token will be selected.
+
+If you have a paid subscription and want to attach to a different token, you
+may want to log in first so that your additional tokens will appear. 
+
+Once you have pasted your code and chosen the subscription you want to attach
+your machine to, click on the "Submit" button.
+
+The attach process will then continue in the terminal window, and you should
+eventually be presented with the following message:
+
+.. code-block:: bash 
+
+    Attaching the machine...
+    Enabling default service esm-apps
+    Updating Ubuntu Pro: ESM Apps package lists
+    Ubuntu Pro: ESM Apps enabled
     Enabling default service esm-infra
-    Updating package lists
-    ESM Infra enabled
-    This machine is now attached to 'Ubuntu Pro'
+    Updating Ubuntu Pro: ESM Infra package lists
+    Ubuntu Pro: ESM Infra enabled
+    Enabling default service livepatch
+    Installing snapd snap
+    Installing canonical-livepatch snap
+    Canonical Livepatch enabled
+    This machine is now attached to 'Ubuntu Pro - free personal subscription'
 
-    SERVICE       ENTITLED  STATUS    DESCRIPTION
-    esm-apps      yes       enabled   Expanded Security Maintenance for Applications
-    esm-infra     yes       enabled   Expanded Security Maintenance for Infrastructure
-    livepatch     yes       enabled   Canonical Livepatch service
-
-    NOTICES
-    Operation in progress: pro attach
-
-    Enable services with: pro enable <service>
+When the machine has successfully been attached, you will also see a summary of
+which services are enabled and information about your subscription.
 
 Once the Ubuntu Pro Client is attached to your Ubuntu Pro account, you can use
 it to activate various services, including: access to ESM packages, Livepatch,
@@ -78,7 +83,12 @@ the ``--no-auto-enable`` flag to ``attach`` in the following way:
 
 .. code-block:: bash
 
-    $ sudo pro attach YOUR_TOKEN --no-auto-enable
+    $ sudo pro attach --no-auto-enable
+
+.. note::
+   
+   If you want to control which services are enabled during attach, you can
+   :ref:`attach with a configuration file <attach-with-config>` instead.
 
 .. LINKS
 

--- a/pro-client/how_to_attach_with_config_file.rst
+++ b/pro-client/how_to_attach_with_config_file.rst
@@ -1,3 +1,5 @@
+.. _attach-with-config:
+
 How to attach with a configuration file
 ***************************************
 
@@ -11,6 +13,27 @@ the secret token in a file.
 
 Optionally, the attached config file can be used to override the services that
 are automatically enabled as a part of the attach process.
+
+
+Get an Ubuntu Pro token
+=======================
+
+Retrieve your Ubuntu Pro token from the `Ubuntu Pro portal <Pro_>`_. Log in
+with your "Single Sign On" credentials, the same credentials you use for
+https://login.ubuntu.com.
+
+After you have logged in you can go to the
+`Ubuntu Pro Dashboard <Pro_dashboard_>`_ associated with your user account. It
+will show you all subscriptions currently available to you and for each
+associated token.
+
+Note that even without buying anything you can always obtain a free personal
+token that way, which provides you with access to several of the Ubuntu Pro
+services.
+
+
+The attach config file
+======================
 
 An attach config file looks like this:
 
@@ -27,3 +50,7 @@ And can be passed via the CLI with the following command:
 .. code-block:: bash
 
     sudo pro attach --attach-config /path/to/file.yaml
+    
+.. LINKS
+
+.. include:: ../links.txt

--- a/start-here.rst
+++ b/start-here.rst
@@ -21,12 +21,12 @@ Instructions on accessing the Ubuntu Pro websites, including troubleshooting gui
 Setting up the Ubuntu Pro services
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Find out how to set up the Ubuntu Pro Client and attach it to your token, then explore the tool to see what the various commands can do for you. 
+Find out how to set up the Ubuntu Pro Client and attach a machine to your subscription, then explore the tool to see what the various commands can do for you. 
 
 .. toctree::
    :maxdepth: 1
 
-   Get your token and attach <pro-client/get_token_and_attach.rst>
+   Attach a machine to your subscription <pro-client/get_token_and_attach.rst>
    Get started with the Ubuntu Pro client <pro-client/basic_commands.rst>
 
 Accessing technical support


### PR DESCRIPTION
We had a duplicate table of contents which was displaying in the LHS 
navigation menu. 

This PR also syncs changes with pro client (updates to attach operation)

Note for reviewers:
- The changes to the attach operation means that references to "get token and 
  attach" are no longer recommended. I need to change the name of the "get token
  and attach" page as a result otherwise the disparity could cause confusion. 
- Do we have a preference for how we want to refer to the process now? (e.g.,
  "attach a machine to your subscription" or something like that?) 