### PR TITLE
Realtime Ubuntu: add 24.04 to supported list

### DIFF
--- a/pro-client/enable_realtime_kernel.rst
+++ b/pro-client/enable_realtime_kernel.rst
@@ -6,8 +6,8 @@ How to manage real-time kernel
 Pre-requisites
 ==============
 
-The `real-time kernel <realtime_>`_ is currently only supported on Ubuntu
-22.04 LTS (Jammy). For more information, feel free to
+The `real-time kernel <realtime_>`_ is currently supported on Ubuntu
+22.04 LTS (Jammy) and 24.04 LTS (Noble). For more information, feel free to
 `contact our real-time team`_.
 
 Enable and auto-install


### PR DESCRIPTION
Adding Realtime Ubuntu 24.04 to supported version as it has been released today: https://ubuntu.com/blog/real-time-24.04

In the long run, this page should instead refer to https://canonical-real-time-ubuntu-documentation.readthedocs-hosted.com/en/latest/how-to/enable-real-time-ubuntu/