### PR TITLE
Update account-setup.rst

### DIFF
--- a/account-setup.rst
+++ b/account-setup.rst
@@ -85,7 +85,7 @@ If a secondary user is not already listed, add one now with the *New user* butto
 Landscape
 ---------
 
-If you have a paid Ubuntu Pro subscription, you are entitled to use Landscape. You can use it either :ref:`Self-hosted <self-hosted-landscape>` (for which you do not need a Landscape account) or as a service (Landscape SaaS).
+If you have a paid Ubuntu Pro subscription, you are entitled to use Landscape. You can use it either :ref:`Self-hosted <self-hosted-landscape>` or as a service (Landscape SaaS).
 
 Set up Landscape SaaS account
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I'd suggest removing the part about self-hosted accounts. Self-hosted deployments still technically need to make a Landscape account (during the installation/configuration process)--they just don't need to create a _SaaS_ account.

Also, there's this link in the Landscape Docs that explains self-hosted Landscape: https://ubuntu.com/landscape/docs/self-hosted-landscape, if you want to link there somewhere (just making sure you know about it :))