### PR TITLE
Removing link to article which no longer exists.

### DIFF
--- a/airgapped-setup.rst
+++ b/airgapped-setup.rst
@@ -7,7 +7,6 @@ Customers with a paid subscription to Ubuntu Pro can set up the included service
 
 Paying customers with Support Portal access should refer to the following articles from our Knowledge Base for instructions on how to set up Ubuntu Pro in offline environments:
 
-* `Ubuntu Pro client external access requirements <https://support-portal.canonical.com/knowledge-base/UA-Client-External-Access-Requirements>`_: this article outlines the specific ports and URLs needed for each Ubuntu Pro bitstream service.
 * `Get started with Ubuntu Pro in an airgapped environment <https://support-portal.canonical.com/knowledge-base/Get-Started-With-Ubuntu-Pro-in-an-Airgapped-Environment>`_.
 * For instructions on how to create local mirrors to make the Pro services available to offline systems, search in the Knowledge Base for "SERVICE_NAME offline".
  


### PR DESCRIPTION
As in the title, updating this content to remove a link which points to an article that has since been taken offline.