### PR TITLE
Ignore support portal in linkcheck

### DIFF
--- a/custom_conf.py
+++ b/custom_conf.py
@@ -169,7 +169,8 @@ intersphinx_disabled_reftypes = ["*"]
 
 # Links to ignore when checking links
 linkcheck_ignore = [
-    'http://127.0.0.1:8000'
+    'http://127.0.0.1:8000',
+    'https://support-portal.canonical.com/*'
     ]
 
 # Pages on which to ignore anchors


### PR DESCRIPTION
The support portal links are suddenly causing linkcheck failures in the CI. The links are not actually broken but do require login. Hence it is better to add these to the ignored links.