### PR TITLE
Fix broken header links

### DIFF
--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -28,7 +28,7 @@
     <ul class="p-navigation__links" role="menu">
 
       <li>
-        <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
+        <a class="p-logo" href="{{ product_page }}" aria-current="page">
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
@@ -36,7 +36,7 @@
       </li>
 
       <li class="nav-ubuntu-com nav-highlighted">
-        <a href="https://{{ product_page }}" class="p-navigation__link">Pro overview</a>
+        <a href="{{ product_page }}" class="p-navigation__link">Pro overview</a>
       </li>
 
       <li class="nav-ubuntu-com">


### PR DESCRIPTION
Currently, because both the template *and* the configuration specify `https://` as a prefix on the homepage and "Pro overview" links browsers (tested under Firefox and Chrome) are rendering the URL as `https://https//ubuntu.com/pro` which is a broken link (e.g. try the top left two links under the [published docs root](https://documentation.ubuntu.com/pro/).

The fix is either to remove the prefix from the template or the configuration; personally I think fixing the template is probably preferable as it shouldn't be "surprising" configuration editors by adding bits to the configured value.